### PR TITLE
Fix path to README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url = "https://github.com/dantaki/vapeplot/",
     packages=['vapeplot'],
     package_dir={'vapeplot':'vapeplot'},
-    long_description=read('README.rst'),
+    long_description=read('README.md'),
     include_package_data=True,
     install_requires=['matplotlib'],
     classifiers=[


### PR DESCRIPTION
I assumed master would be stable and ready for a pip install but it crashes on `FileNotFoundError`.

```
pip install git+https://github.com/dantaki/vapeplot.git                           

Collecting git+https://github.com/dantaki/vapeplot.git
  Cloning https://github.com/dantaki/vapeplot.git to /tmp/pip-o0zcq8ye-build
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-o0zcq8ye-build/setup.py", line 16, in <module>
        long_description=read('README.rst'),
      File "/tmp/pip-o0zcq8ye-build/setup.py", line 4, in read
        return open(os.path.join(os.path.dirname(__file__), fname)).read()
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-o0zcq8ye-build/README.rst'
```