### PR TITLE
Fix relative import

### DIFF
--- a/vapeplot/__init__.py
+++ b/vapeplot/__init__.py
@@ -1,1 +1,1 @@
-from vapeplot import *
+from .vapeplot import *


### PR DESCRIPTION
No usage examples in the README actually work at the moment after doing a `pip install vapeplot` because `__init__.py` imports the pip installed package, and not the module vapeplot.py (due to the name collision). 

By making `__init__.py` look for a relative import the examples should start to work as expected, I believe.
