### PR TITLE
Added avanti colorscheme

### DIFF
--- a/vapeplot/vapeplot.py
+++ b/vapeplot/vapeplot.py
@@ -14,7 +14,8 @@ palettes = {
     "jazzcup": ["#392682", "#7a3a9a", "#3f86bc", "#28ada8", "#83dde0"],
     "sunset": ["#661246", "#ae1357", "#f9247e", "#d7509f", "#f9897b"],
     "macplus": ["#1b4247", "#09979b", "#75d8d5", "#ffc0cb", "#fe7f9d", "#65323e"],
-    "seapunk": ["#532e57", "#a997ab", "#7ec488", "#569874", "#296656"]
+    "seapunk": ["#532e57", "#a997ab", "#7ec488", "#569874", "#296656"],
+    "avanti": ["#FB4142", "#94376C", "#CE75AD", "#76BDCF", "#9DCFF0"]
 }
 
 # avoid plotly import if not using
@@ -25,7 +26,7 @@ def available(show=True):
     if not show:
         return palettes.keys()
     else:
-        f, ax = plt.subplots(4, 2, figsize=(5, 8))
+        f, ax = plt.subplots(5, 2, figsize=(5, 8))
         for i, name in enumerate(palettes.keys()):
             x, y = i // 2, i % 2
             cycle = palettes[name]


### PR DESCRIPTION
I've added a colorscheme named "Avanti", named and styled after the Avanti line of VHS tapes.
![the Avanti line of VHS tapes](https://user-images.githubusercontent.com/8935879/47541247-9b82a000-d8a6-11e8-92ae-6b30272e36fb.jpg). 

All the commands I can test locally build fine, but I can't install seaborns for unrelated reasons. Here's a screenshot of `view_palette('avanti')`:

![Here's a screenshot of view_palette('avanti')](https://user-images.githubusercontent.com/8935879/47541201-70984c00-d8a6-11e8-9394-f8caff952ed3.png)

Whether this theme ends up getting merged or not, I really like your project! Thanks for doing it!
